### PR TITLE
add script to auto discovery and add tapo device into home assistant

### DIFF
--- a/API/utilities/tapo_add_device.py
+++ b/API/utilities/tapo_add_device.py
@@ -1,0 +1,41 @@
+"""
+This script adds a Tapo device to Home Assistant.
+It uses the Home Assistant API to add the device. 
+The script sends a POST request to the Home Assistant API with the device's IP address, username, and password.
+"""
+
+import requests
+ha_ip = "163.22.17.184"
+home_assistant_token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiI4OTI2YzE0OTI2YzY0ZTBmYWQ5MGJhNDc1YjBkYTM2NiIsImlhdCI6MTcyMjI0MjAwNiwiZXhwIjoyMDM3NjAyMDA2fQ.DfwflG8zTXQOy5QCy_xn1QjPApSSgqKFV4bYNzpyAjY'
+host = "192.168.0.199" # device ip
+user_name = "annnna6633@gmail.com"
+password = "a12345678"
+
+# Define the URL and headers
+url = "http://%s/api/config/config_entries/flow/e9058a096ed38fb9c934cb61ef2c9e7c" % host
+headers = {
+    'Authorization': f'Bearer {home_assistant_token}',
+    'Content-Type': 'application/json'
+}
+
+def get_flow_id():
+    payload = {
+        'handler': 'tapo',
+        'show_advanced_options': True
+    }
+    
+    url = 'http://%s:8123/api/config/config_entries/flow' % ha_ip
+    response = requests.post(url, json=payload, headers=headers)
+    return response.json()['flow_id']
+
+def main(flow_id):
+    payload = {
+            'host': host,
+            'username': user_name,
+            'password': password
+    }
+    url = 'http://%s:8123/api/config/config_entries/flow/%s' % (ha_ip, flow_id)
+    response = requests.post(url, json=payload, headers=headers)
+    print(response.json(), url)
+
+main(get_flow_id())

--- a/API/utilities/tapo_discover.py
+++ b/API/utilities/tapo_discover.py
@@ -1,0 +1,31 @@
+import asyncio
+import logging
+from plugp100.common.credentials import AuthCredential
+from plugp100.discovery.tapo_discovery import TapoDiscovery
+
+async def example_discovery(credentials: AuthCredential):
+    discovered = await TapoDiscovery.scan(timeout=30)
+    print(f"Discovered {len(discovered)} devices")
+    for discovered_device in discovered:
+        try:
+            device = await discovered_device.get_tapo_device(credentials)
+            await device.update()
+            print({
+                'type': type(device),
+                'protocol': device.protocol_version,
+                'raw_state': device.raw_state
+            })
+            await device.client.close()
+        except Exception as e:
+            print(f"Failed to update {discovered_device.ip} {discovered_device.device_type}", e)
+            logging.error(f"Failed to update {discovered_device.ip} {discovered_device.device_type}", exc_info=e)
+
+async def main():
+    credentials = AuthCredential("annnna6633@gmail.com", "a12345678")
+    await example_discovery(credentials)
+
+if __name__ == "__main__":
+    loop = asyncio.new_event_loop()
+    loop.run_until_complete(main())
+    loop.run_until_complete(asyncio.sleep(0.1))
+    loop.close()

--- a/HaWebTunnelling/HaWebTunnelling.sh
+++ b/HaWebTunnelling/HaWebTunnelling.sh
@@ -3,7 +3,7 @@
 # this script is used for port forwarding the HA web from this private ip only host to a host have public ip
 
 # Check if any process contains "homeassistant.local"
-if curl -s --head --request GET http://163.22.17.184:8123 | grep "200 OK" > /dev/null; then
+if curl -s --head --request GET http://163.22.17.184:8123 --max-time 5 | grep "200 OK" > /dev/null; then
     echo "`date` : ssh tunnelling process is running." >> ./result.txt
 else
     echo "`date` : No ssh tunnelling process found" >> ./result.txt

--- a/HaWebTunnelling/HaWebTunnelling.sh
+++ b/HaWebTunnelling/HaWebTunnelling.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# this script is used for port forwarding the HA web from this private ip only host to a host have public ip
+
+# Check if any process contains "homeassistant.local"
+if curl -s --head --request GET http://163.22.17.184:8123 | grep "200 OK" > /dev/null; then
+    echo "`date` : ssh tunnelling process is running." >> ./result.txt
+else
+    echo "`date` : No ssh tunnelling process found" >> ./result.txt
+    ssh tommygood@163.22.17.184 "pid=\$(sudo netstat -tupln | grep 8123 | awk '{print \$7}' | cut -d'/' -f1); if [ -n \"\$pid\" ]; then sudo kill -9 \$pid; else echo 'No process found using port 8123'; fi"
+    ssh -fNR 0.0.0.0:8123:homeassistant.local:8123 tommygood@163.22.17.184
+fi

--- a/HaWebTunnelling/main.py
+++ b/HaWebTunnelling/main.py
@@ -1,0 +1,35 @@
+# auto execute the shell script to make sure ssh tunnel is work normally
+
+from urllib import request
+import time, os, subprocess, threading, datetime
+
+def internetOn():
+    try:
+        request.urlopen('https://www.google.com', timeout=1)
+        return True
+    except request.URLError as err:
+        return False
+
+def reboot() :
+    # double check if the internet is broken
+    connect_to_internet = internetOn()
+    if connect_to_internet == False :
+        f = open("result.txt", "a")
+        f.write("Error : internet disconnected at " + datetime.datetime.now())
+        f.close()
+        os.system('reboot')
+
+def main() :
+    while True :
+        #connect_to_internet = internetOn()
+        #if connect_to_internet == False :
+        #    reboot()
+
+        time.sleep(30)
+        process = subprocess.Popen(['bash', './HaWebTunnelling.sh'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        out, err = process.communicate()
+        #print(out, err)
+
+thread = threading.Thread(target=main, daemon=True)
+thread.start()
+thread.join()


### PR DESCRIPTION

- 在樹莓派掃描附近的 tapo device（必須已經有用 tapo app 設定 ip）
  - ![image](https://github.com/user-attachments/assets/d23f4a40-85bd-4e3b-9549-cf7e7ead1ccd)
  
- 新增 tapo device with device ip
  ```
  D:\program\HomeAssisstantIntegration\API\utilities>python tapo_add_device.py
  {'type': 'create_entry', 'flow_id': 'ecc95bb0be14da2a162180b7d9e51b1f', 'handler': 'tapo', 'description': None, 'description_placeholders': None, 'title': '智慧型插座', 'options': {}, 'minor_version': 1, 'version': 5, 'result': {'entry_id': 'be861a15269cce71f6f467f6286d4688', 'domain': 'tapo', 'title': '智慧型插座', 'source': 'user', 'state': 'loaded', 'supports_options': True, 'supports_remove_device': False, 'supports_unload': True, 'supports_reconfigure': False, 'pref_disable_new_entities': False, 'pref_disable_polling': False, 'disabled_by': None, 'reason': None, 'error_reason_translation_key': None, 'error_reason_translation_placeholders': None}} http://163.22.17.184:8123/api/config/config_entries/flow/ecc95bb0be14da2a162180b7d9e51b1f
  ```

> 省略掉打開web，點擊"設定"->"整合與服務"->"TP-Link Tapo"->"新增裝置"，
> 再手動輸入 『device ip、tapo app的帳號、密碼』的步驟
  - 可以在 http://163.22.17.184:8123/config/integrations/integration/tapo 看到新增的裝置
  - ![image](https://github.com/user-attachments/assets/05dd58e1-67c4-4ed6-a9ee-9d6448bb424e)


@weiyo176 
- 你可以測試看看功能是否正常，有問題再跟我說，如果沒問題的話可以幫忙加到 api 裡面讓前端呼叫，謝謝。